### PR TITLE
Copy History

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -1,0 +1,7 @@
+{
+  "jsc": {
+    "experimental": {
+      "plugins": [["@swc-jotai/react-refresh", {}]]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The AliasIpsum extension giving access to a unique, timstamp based aliased
 email that updates each second, so there is nearly 0 chance that the email 
 copied is not unique.
 
+Download the browser extension for free in the [Chrome Web Store](https://chrome.google.com/webstore/detail/aliasipsum/gpbdnbechbkbfbdbhcbllejhgggnmena)
+
 
 ## QuickLorem.dev started out as a superfast lorem ipsum Generator
 
@@ -18,8 +20,18 @@ faster than other tools. Lets focus on getting the data that matters copied quic
   - String[]
   - Number[]
   - Json
+- Aliased Emails
 
 ---
 
 ## Contribute
-Fork/Branch this repo. Make improvements. Open a Pull Request.
+Fork/Branch this repo. 
+
+`npm run dev` to get the site running in localhost. 
+
+To develop the extension, use the `/extension` page. 
+
+Chrome browsers allow user to manually upload an extension as a folder. 
+Run `npm run build:extension` to export the `/extension` page as an 
+extension and upload the extension folder into the extension manager in Chrome.
+

--- a/components/AliasedEmails.tsx
+++ b/components/AliasedEmails.tsx
@@ -30,7 +30,7 @@ type Alias = {
   label: string
   value: string
 }
-type CopyHistory = {
+export type CopyHistory = {
   id: number
   type: "email" | "text"
   value: string
@@ -120,11 +120,11 @@ export default function InputCreator({ extension }: Props) {
     }
   }
 
-  const setHistory = useSetAtom(localCopyHistoryAtom)
+  const [copyHistory, setCopyHistory] = useAtom(localCopyHistoryAtom)
 
   const handleCopyEmail = () => {
     setCopiedEmail(aliasedEmail)
-    setHistory((history) => [
+    setCopyHistory((history) => [
       ...history,
       { id: history.length, type: "email", value: aliasedEmail },
     ])

--- a/components/AliasedEmails.tsx
+++ b/components/AliasedEmails.tsx
@@ -22,7 +22,7 @@ import {
   IconX,
 } from "@tabler/icons-react"
 import { useEffect, useState } from "react"
-import { atom, useAtom, useAtomValue, useSetAtom } from "jotai"
+import { useAtom } from "jotai"
 import { atomWithStorage } from "jotai/utils"
 
 type Props = { extension?: boolean }
@@ -234,6 +234,7 @@ export default function InputCreator({ extension }: Props) {
               <Select
                 clearable
                 allowDeselect
+                withinPortal
                 placeholder="Timestamp"
                 value={selectedAlias}
                 data={aliases}

--- a/components/AliasedEmails.tsx
+++ b/components/AliasedEmails.tsx
@@ -22,12 +22,21 @@ import {
   IconX,
 } from "@tabler/icons-react"
 import { useEffect, useState } from "react"
+import { atom, useAtom, useAtomValue, useSetAtom } from "jotai"
+import { atomWithStorage } from "jotai/utils"
 
 type Props = { extension?: boolean }
 type Alias = {
   label: string
   value: string
 }
+type CopyHistory = {
+  id: number
+  type: "email" | "text"
+  value: string
+}
+
+const localCopyHistoryAtom = atomWithStorage("copyHistory", [] as CopyHistory[])
 
 export default function InputCreator({ extension }: Props) {
   const [email, setEmail] = useLocalStorage({ key: "email", defaultValue: "" })
@@ -111,8 +120,14 @@ export default function InputCreator({ extension }: Props) {
     }
   }
 
+  const setHistory = useSetAtom(localCopyHistoryAtom)
+
   const handleCopyEmail = () => {
     setCopiedEmail(aliasedEmail)
+    setHistory((history) => [
+      ...history,
+      { id: history.length, type: "email", value: aliasedEmail },
+    ])
   }
 
   return (

--- a/components/AliasedEmails.tsx
+++ b/components/AliasedEmails.tsx
@@ -23,23 +23,14 @@ import {
 } from "@tabler/icons-react"
 import { useEffect, useState } from "react"
 import { useAtom } from "jotai"
-import { atomWithStorage } from "jotai/utils"
+import { localCopyHistoryAtom } from "@/pages/_app"
+import { colorSelector } from "@/utils/colorSelector"
 
 type Props = { extension?: boolean }
 type Alias = {
   label: string
   value: string
 }
-export type CopyHistory = {
-  id: number
-  type: "email" | "text"
-  value: string
-}
-
-export const localCopyHistoryAtom = atomWithStorage(
-  "copyHistory",
-  [] as CopyHistory[]
-)
 
 export default function InputCreator({ extension }: Props) {
   const [email, setEmail] = useLocalStorage({ key: "email", defaultValue: "" })
@@ -277,6 +268,7 @@ export default function InputCreator({ extension }: Props) {
                   onClick={copy}
                   rightIcon={<IconCopy />}
                   disabled={!validateEmail(email) || email.length === 0}
+                  color={colorSelector("email")}
                 >
                   {copied ? `Copied ${copiedEmail}` : `${aliasedEmail}`}
                 </Button>

--- a/components/AliasedEmails.tsx
+++ b/components/AliasedEmails.tsx
@@ -36,7 +36,10 @@ export type CopyHistory = {
   value: string
 }
 
-const localCopyHistoryAtom = atomWithStorage("copyHistory", [] as CopyHistory[])
+export const localCopyHistoryAtom = atomWithStorage(
+  "copyHistory",
+  [] as CopyHistory[]
+)
 
 export default function InputCreator({ extension }: Props) {
   const [email, setEmail] = useLocalStorage({ key: "email", defaultValue: "" })
@@ -124,6 +127,8 @@ export default function InputCreator({ extension }: Props) {
 
   const handleCopyEmail = () => {
     setCopiedEmail(aliasedEmail)
+
+    if (copyHistory.find((item) => item.value === aliasedEmail)) return
     setCopyHistory((history) => [
       ...history,
       { id: history.length, type: "email", value: aliasedEmail },

--- a/components/ConfirmationPopup.tsx
+++ b/components/ConfirmationPopup.tsx
@@ -1,0 +1,56 @@
+import {
+  Button,
+  Group,
+  HoverCard,
+  MantineColor,
+  Stack,
+  Text,
+} from "@mantine/core"
+import React from "react"
+
+type Props = {
+  title?: string
+  description?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  onConfirm: () => void
+  onCancel?: () => void
+  children: React.ReactNode
+  confirmColor?: MantineColor
+  cancelColor?: MantineColor
+  [x: string]: any
+}
+export default function ConfirmationPopup({
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+  confirmColor,
+  cancelColor,
+  children,
+  ...rest
+}: Props) {
+  return (
+    <Group {...rest}>
+      <HoverCard closeDelay={400}>
+        <HoverCard.Target>{children}</HoverCard.Target>
+        <HoverCard.Dropdown>
+          <Stack>
+            {title && <Text>{title}</Text>}
+            {description && <Text color="dimmed">{description}</Text>}
+            <Button.Group>
+              <Button color={confirmColor || "green"} onClick={onConfirm}>
+                {confirmLabel || "ok"}
+              </Button>
+              <Button color={cancelColor || "grey"} onClick={onCancel}>
+                {cancelLabel || "cancel"}
+              </Button>
+            </Button.Group>
+          </Stack>
+        </HoverCard.Dropdown>
+      </HoverCard>
+    </Group>
+  )
+}

--- a/components/ConfirmationPopup.tsx
+++ b/components/ConfirmationPopup.tsx
@@ -16,6 +16,7 @@ type Props = {
   confirmLabel?: string
   cancelLabel?: string
   onConfirm: () => void
+  onCancel?: () => void
   confirmColor?: MantineColor
   cancelColor?: MantineColor
   [x: string]: any
@@ -35,7 +36,9 @@ export default function ConfirmationPopup({
   const [opened, setOpened] = useState(false)
 
   const handleCancel = () => {
-    onCancel()
+    {
+      onCancel && onCancel()
+    }
     setOpened(false)
   }
 

--- a/components/ConfirmationPopup.tsx
+++ b/components/ConfirmationPopup.tsx
@@ -1,12 +1,14 @@
 import {
+  Badge,
   Button,
   Group,
-  HoverCard,
   MantineColor,
+  Popover,
   Stack,
   Text,
 } from "@mantine/core"
-import React from "react"
+import { useHover } from "@mantine/hooks"
+import React, { useState } from "react"
 
 type Props = {
   title?: string
@@ -14,8 +16,6 @@ type Props = {
   confirmLabel?: string
   cancelLabel?: string
   onConfirm: () => void
-  onCancel?: () => void
-  children: React.ReactNode
   confirmColor?: MantineColor
   cancelColor?: MantineColor
   [x: string]: any
@@ -32,25 +32,59 @@ export default function ConfirmationPopup({
   children,
   ...rest
 }: Props) {
+  const [opened, setOpened] = useState(false)
+
+  const handleCancel = () => {
+    onCancel()
+    setOpened(false)
+  }
+
+  const handleConfirm = () => {
+    onConfirm()
+    setOpened(false)
+  }
+
+  const { hovered, ref } = useHover()
+
   return (
     <Group {...rest}>
-      <HoverCard closeDelay={400}>
-        <HoverCard.Target>{children}</HoverCard.Target>
-        <HoverCard.Dropdown>
+      <Popover opened={opened} width={"target"}>
+        <Popover.Target>
+          <Badge
+            ref={ref}
+            sx={{ cursor: "pointer" }}
+            color={hovered || opened ? "red" : "gray"}
+            w={"100%"}
+            onClick={() => {
+              setOpened(true)
+            }}
+          >
+            Clear History
+          </Badge>
+        </Popover.Target>
+        <Popover.Dropdown>
           <Stack>
             {title && <Text>{title}</Text>}
             {description && <Text color="dimmed">{description}</Text>}
             <Button.Group>
-              <Button color={confirmColor || "green"} onClick={onConfirm}>
+              <Button
+                w={"100%"}
+                color={confirmColor || "green"}
+                onClick={handleConfirm}
+              >
                 {confirmLabel || "ok"}
               </Button>
-              <Button color={cancelColor || "grey"} onClick={onCancel}>
+              <Button
+                w={"100%"}
+                color={cancelColor || "grey"}
+                onClick={() => handleCancel()}
+              >
                 {cancelLabel || "cancel"}
               </Button>
             </Button.Group>
           </Stack>
-        </HoverCard.Dropdown>
-      </HoverCard>
+        </Popover.Dropdown>
+      </Popover>
     </Group>
   )
 }

--- a/components/CopyHistory.tsx
+++ b/components/CopyHistory.tsx
@@ -2,13 +2,16 @@ import React, { useState } from "react"
 import { useAtomValue } from "jotai"
 import {
   Button,
+  Card,
   CopyButton,
   MantineNumberSize,
   SimpleGrid,
   Tooltip,
 } from "@mantine/core"
-import { CopyHistory, localCopyHistoryAtom } from "./AliasedEmails"
+import { CopyHistory, localCopyHistoryAtom } from "@/pages/_app"
 import { IconCopy } from "@tabler/icons-react"
+import { colorSelector } from "@/utils/colorSelector"
+import { useRouter } from "next/router"
 
 type Props = {
   type?: "email" | "text"
@@ -17,7 +20,12 @@ type Props = {
   scrollThreshold: number
 }
 
-export default function CopyHistory({ type, spacing, tooltip, scrollThreshold }: Props) {
+export default function CopyHistory({
+  type,
+  spacing,
+  tooltip,
+  scrollThreshold,
+}: Props) {
   let copyHistory = useAtomValue(localCopyHistoryAtom)
 
   type == "email" &&
@@ -38,7 +46,7 @@ export default function CopyHistory({ type, spacing, tooltip, scrollThreshold }:
   }) => {
     const [hovered, setHovered] = useState(false)
 
-    const scalingFactor = 1.01
+    const scalingFactor = 1
 
     const scrollSpeed = (scrollThreshold: number) => {
       const speed = scrollThreshold * 0.02
@@ -101,14 +109,14 @@ export default function CopyHistory({ type, spacing, tooltip, scrollThreshold }:
                       ? { hover: true, focus: true, touch: true }
                       : { hover: false, focus: false, touch: false }
                   }
-                  openDelay={1000}
+                  openDelay={800}
                   withinPortal
                   position={"bottom"}
                 >
                   <Button
                     leftIcon={<IconCopy />}
-                    color={"cyan"}
-                    variant={copied ? "light" : "default"}
+                    color={colorSelector(item.type)}
+                    variant={copied ? "filled" : "outline"}
                     onClick={copy}
                     key={item.id}
                   >
@@ -117,7 +125,12 @@ export default function CopyHistory({ type, spacing, tooltip, scrollThreshold }:
                       scrolling={copied ? false : true}
                     >
                       {copied
-                        ? `${item.value} copied!`
+                        ? `${
+                            item.type === "email"
+                              ? item.value
+                              : item.type.charAt(0).toUpperCase() +
+                                item.type.slice(1)
+                          }  Copied!`
                         : `${item.id}: ${item.value}`}
                     </ScrollingText>
                   </Button>

--- a/components/CopyHistory.tsx
+++ b/components/CopyHistory.tsx
@@ -1,52 +1,64 @@
 import React from "react"
 import { useAtomValue } from "jotai"
-import { Button, CopyButton, SimpleGrid, Tooltip } from "@mantine/core"
+import {
+  Button,
+  CopyButton,
+  MantineNumberSize,
+  SimpleGrid,
+  Tooltip,
+} from "@mantine/core"
 import { CopyHistory, localCopyHistoryAtom } from "./AliasedEmails"
 import { IconCopy } from "@tabler/icons-react"
 
-type Props = {}
+type Props = {
+  type?: "email" | "text"
+  spacing?: MantineNumberSize
+}
 
-export default function CopyHistory({}: Props) {
-  const History = () => {
-    const copyHistory = useAtomValue(localCopyHistoryAtom)
-    return (
-      <>
-        {copyHistory
-          .sort((a, b) => b.id - a.id)
-          .map((item) => {
-            return (
-              <CopyButton value={item.value} timeout={5000}>
-                {({ copied, copy }) => (
-                  <Tooltip
-                    label={item.value}
-                    events={{ hover: true, focus: true, touch: true }}
-                    withinPortal
-                    position={"bottom"}
-                  >
-                    <Button
-                      leftIcon={<IconCopy />}
-                      compact
-                      color="violet"
-                      variant={copied ? "white" : "outline"}
-                      onClick={copy}
-                      key={item.id}
-                    >
-                      {copied
-                        ? `Copied ${item.value}`
-                        : `${item.id}: ${item.value}`}
-                    </Button>
-                  </Tooltip>
-                )}
-              </CopyButton>
-            )
-          })}
-      </>
-    )
-  }
+export default function CopyHistory({ type, spacing }: Props) {
+  let copyHistory = useAtomValue(localCopyHistoryAtom)
+
+  type == "email" &&
+    (copyHistory = copyHistory.filter((item) => item.type === type))
+
+  type == "text" &&
+    (copyHistory = copyHistory.filter((item) => item.type === type))
 
   return (
-    <SimpleGrid cols={1}>
-      <History />
+    <SimpleGrid cols={1} spacing={spacing}>
+      {copyHistory
+        .sort((a, b) => b.id - a.id)
+        .map((item) => {
+          return (
+            <CopyButton value={item.value} timeout={5000}>
+              {({ copied, copy }) => (
+                <Tooltip
+                  label={item.value}
+                  events={{ hover: true, focus: true, touch: true }}
+                  withinPortal
+                  position={"bottom"}
+                >
+                  <Button
+                    leftIcon={<IconCopy />}
+                    compact
+                    color="violet"
+                    variant={copied ? "white" : "outline"}
+                    onClick={copy}
+                    key={item.id}
+                  >
+                    {copied
+                      ? `Copied ${item.value}`
+                      : `${item.id}: ${item.value}`}
+                  </Button>
+                </Tooltip>
+              )}
+            </CopyButton>
+          )
+        })}
     </SimpleGrid>
   )
 }
+
+
+
+

--- a/components/CopyHistory.tsx
+++ b/components/CopyHistory.tsx
@@ -1,25 +1,52 @@
 import React from "react"
-import { atom, useAtom, useAtomValue } from "jotai"
-import { atomWithStorage } from "jotai/utils"
-import { Box, List } from "@mantine/core"
-import { CopyHistory } from "./AliasedEmails"
+import { useAtomValue } from "jotai"
+import { Button, CopyButton, SimpleGrid, Tooltip } from "@mantine/core"
+import { CopyHistory, localCopyHistoryAtom } from "./AliasedEmails"
+import { IconCopy } from "@tabler/icons-react"
 
 type Props = {}
-
-const localCopyHistoryAtom = atomWithStorage("copyHistory", [] as CopyHistory[])
 
 export default function CopyHistory({}: Props) {
   const History = () => {
     const copyHistory = useAtomValue(localCopyHistoryAtom)
-
     return (
-      <List>
-        {copyHistory.map((item) => {
-          return <List.Item key={item.id}>{item.value}</List.Item>
-        })}
-      </List>
+      <>
+        {copyHistory
+          .sort((a, b) => b.id - a.id)
+          .map((item) => {
+            return (
+              <CopyButton value={item.value} timeout={5000}>
+                {({ copied, copy }) => (
+                  <Tooltip
+                    label={item.value}
+                    events={{ hover: true, focus: true, touch: true }}
+                    withinPortal
+                    position={"bottom"}
+                  >
+                    <Button
+                      leftIcon={<IconCopy />}
+                      compact
+                      color="violet"
+                      variant={copied ? "white" : "outline"}
+                      onClick={copy}
+                      key={item.id}
+                    >
+                      {copied
+                        ? `Copied ${item.value}`
+                        : `${item.id}: ${item.value}`}
+                    </Button>
+                  </Tooltip>
+                )}
+              </CopyButton>
+            )
+          })}
+      </>
     )
   }
 
-  return <History />
+  return (
+    <SimpleGrid cols={1}>
+      <History />
+    </SimpleGrid>
+  )
 }

--- a/components/CopyHistory.tsx
+++ b/components/CopyHistory.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { atom, useAtom, useAtomValue } from "jotai"
+import { atomWithStorage } from "jotai/utils"
+import { Box, List } from "@mantine/core"
+import { CopyHistory } from "./AliasedEmails"
+
+type Props = {}
+
+const localCopyHistoryAtom = atomWithStorage("copyHistory", [] as CopyHistory[])
+
+export default function CopyHistory({}: Props) {
+  const History = () => {
+    const copyHistory = useAtomValue(localCopyHistoryAtom)
+
+    return (
+      <List>
+        {copyHistory.map((item) => {
+          return <List.Item key={item.id}>{item.value}</List.Item>
+        })}
+      </List>
+    )
+  }
+
+  return <History />
+}

--- a/components/CopyHistory.tsx
+++ b/components/CopyHistory.tsx
@@ -14,15 +14,10 @@ type Props = {
   type?: "email" | "text"
   spacing?: MantineNumberSize
   tooltip?: boolean
-  threshold?: number
+  scrollThreshold: number
 }
 
-export default function CopyHistory({
-  type,
-  spacing,
-  tooltip,
-  threshold,
-}: Props) {
+export default function CopyHistory({ type, spacing, tooltip, scrollThreshold }: Props) {
   let copyHistory = useAtomValue(localCopyHistoryAtom)
 
   type == "email" &&
@@ -33,18 +28,20 @@ export default function CopyHistory({
 
   const ScrollingText = ({
     children,
-    threshold,
+    scrollThreshold,
+    scrolling,
     ...rest
   }: {
     children: String
-    threshold?: number
+    scrollThreshold: number
+    scrolling: boolean
   }) => {
     const [hovered, setHovered] = useState(false)
 
-    const scalingFactor = 0.9
-    threshold == undefined && (threshold = 39)
-    const scrollSpeed = (threshold: number) => {
-      const speed = threshold * 0.02
+    const scalingFactor = 1.01
+
+    const scrollSpeed = (scrollThreshold: number) => {
+      const speed = scrollThreshold * 0.02
       if (speed > 0.8) {
         return 0.8
       } else {
@@ -52,11 +49,11 @@ export default function CopyHistory({
       }
     }
 
-    const scrollAmount = (threshold: number) => {
-      if (children.length <= threshold) {
+    const scrollAmount = (scrollThreshold: number) => {
+      if (children.length <= scrollThreshold) {
         return 0
       } else {
-        return (threshold - children.length) * scalingFactor + "ch"
+        return (scrollThreshold - children.length) * scalingFactor + "ch"
       }
     }
 
@@ -67,12 +64,21 @@ export default function CopyHistory({
         {...rest}
       >
         <div
-          style={{
-            transform: hovered
-              ? `translateX(${scrollAmount(threshold)})`
-              : "translateX(0)",
-            transition: `transform ${scrollSpeed(threshold)}s ease-out`,
-          }}
+          style={
+            scrolling
+              ? {
+                  transform: hovered
+                    ? `translateX(${scrollAmount(scrollThreshold)})`
+                    : "translateX(0)",
+                  transition: `transform ${scrollSpeed(
+                    scrollThreshold
+                  )}s ease-out`,
+                }
+              : {
+                  transform: `translateX(${scrollAmount(scrollThreshold)})`,
+                  transition: `transform 0.1s ease-out`,
+                }
+          }
         >
           {children}
         </div>
@@ -101,15 +107,17 @@ export default function CopyHistory({
                 >
                   <Button
                     leftIcon={<IconCopy />}
-                    compact
                     color="violet"
-                    variant={copied ? "white" : "outline"}
+                    variant={copied ? "white" : "default"}
                     onClick={copy}
                     key={item.id}
                   >
-                    <ScrollingText threshold={threshold}>
+                    <ScrollingText
+                      scrollThreshold={scrollThreshold}
+                      scrolling={copied ? false : true}
+                    >
                       {copied
-                        ? `Copied ${item.value}`
+                        ? `${item.value} copied!`
                         : `${item.id}: ${item.value}`}
                     </ScrollingText>
                   </Button>

--- a/components/CopyHistory.tsx
+++ b/components/CopyHistory.tsx
@@ -107,8 +107,8 @@ export default function CopyHistory({ type, spacing, tooltip, scrollThreshold }:
                 >
                   <Button
                     leftIcon={<IconCopy />}
-                    color="violet"
-                    variant={copied ? "white" : "default"}
+                    color={"cyan"}
+                    variant={copied ? "light" : "default"}
                     onClick={copy}
                     key={item.id}
                   >

--- a/components/CopyHistory.tsx
+++ b/components/CopyHistory.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { useAtomValue } from "jotai"
 import {
   Button,
@@ -13,9 +13,16 @@ import { IconCopy } from "@tabler/icons-react"
 type Props = {
   type?: "email" | "text"
   spacing?: MantineNumberSize
+  tooltip?: boolean
+  threshold?: number
 }
 
-export default function CopyHistory({ type, spacing }: Props) {
+export default function CopyHistory({
+  type,
+  spacing,
+  tooltip,
+  threshold,
+}: Props) {
   let copyHistory = useAtomValue(localCopyHistoryAtom)
 
   type == "email" &&
@@ -23,6 +30,55 @@ export default function CopyHistory({ type, spacing }: Props) {
 
   type == "text" &&
     (copyHistory = copyHistory.filter((item) => item.type === type))
+
+  const ScrollingText = ({
+    children,
+    threshold,
+    ...rest
+  }: {
+    children: String
+    threshold?: number
+  }) => {
+    const [hovered, setHovered] = useState(false)
+
+    const scalingFactor = 0.9
+    threshold == undefined && (threshold = 39)
+    const scrollSpeed = (threshold: number) => {
+      const speed = threshold * 0.02
+      if (speed > 0.8) {
+        return 0.8
+      } else {
+        return speed
+      }
+    }
+
+    const scrollAmount = (threshold: number) => {
+      if (children.length <= threshold) {
+        return 0
+      } else {
+        return (threshold - children.length) * scalingFactor + "ch"
+      }
+    }
+
+    return (
+      <div
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        {...rest}
+      >
+        <div
+          style={{
+            transform: hovered
+              ? `translateX(${scrollAmount(threshold)})`
+              : "translateX(0)",
+            transition: `transform ${scrollSpeed(threshold)}s ease-out`,
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    )
+  }
 
   return (
     <SimpleGrid cols={1} spacing={spacing}>
@@ -34,7 +90,12 @@ export default function CopyHistory({ type, spacing }: Props) {
               {({ copied, copy }) => (
                 <Tooltip
                   label={item.value}
-                  events={{ hover: true, focus: true, touch: true }}
+                  events={
+                    tooltip === true || tooltip === undefined
+                      ? { hover: true, focus: true, touch: true }
+                      : { hover: false, focus: false, touch: false }
+                  }
+                  openDelay={1000}
                   withinPortal
                   position={"bottom"}
                 >
@@ -46,9 +107,11 @@ export default function CopyHistory({ type, spacing }: Props) {
                     onClick={copy}
                     key={item.id}
                   >
-                    {copied
-                      ? `Copied ${item.value}`
-                      : `${item.id}: ${item.value}`}
+                    <ScrollingText threshold={threshold}>
+                      {copied
+                        ? `Copied ${item.value}`
+                        : `${item.id}: ${item.value}`}
+                    </ScrollingText>
                   </Button>
                 </Tooltip>
               )}
@@ -58,7 +121,3 @@ export default function CopyHistory({ type, spacing }: Props) {
     </SimpleGrid>
   )
 }
-
-
-
-

--- a/components/HomepageHero.tsx
+++ b/components/HomepageHero.tsx
@@ -13,9 +13,9 @@ export default function HomepageHero({ ...rest }) {
             gradient={{ from: "blue", to: "cyan", deg: 45 }}
             inherit
           >
-            Lorem Ipsum
+            Placeholder Text
           </Text>{" "}
-          faster
+          Faster
         </Title>
         <Text color="dimmed">
           Copy the content you need to your clipboard with one click

--- a/components/TextGeneration.tsx
+++ b/components/TextGeneration.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   Card,
+  Container,
   CopyButton,
   Grid,
   Select,
@@ -11,9 +12,12 @@ import {
 } from "@mantine/core"
 import React, { useState } from "react"
 import { PlaceText } from "../utils/transformer"
+import { useAtom } from "jotai"
+import { localCopyHistoryAtom } from "@/pages/_app"
+import { colorSelector } from "@/utils/colorSelector"
 
 interface Props {
-  extension?: boolean,
+  extension?: boolean
   defaultOptions: {
     label: string
     textElement: string
@@ -98,34 +102,20 @@ export default function CopyGroupCard({ defaultOptions }: Props) {
 export const CopyButtons = ({
   label,
   textElement,
-  text,
+  text: value,
+  ...rest
 }: {
   label: string
   textElement: string
   text: string
 }) => {
-  const colorScheme: string = (() => {
-    switch (textElement) {
-      case "sentences":
-        return "teal"
-      case "paragraphs":
-        return "indigo"
-      case "words":
-        return "red"
-      case "json":
-        return "orange"
-      case "array":
-        return "yellow"
-      default:
-        return "black"
-    }
-  })()
+  const [copyHistory, setCopyHistory] = useAtom(localCopyHistoryAtom)
 
   return (
-    <CopyButton value={text}>
+    <CopyButton value={value} {...rest}>
       {({ copied, copy }) => (
         <Tooltip
-          label={text}
+          label={value}
           withinPortal
           multiline
           maw={400}
@@ -137,9 +127,21 @@ export const CopyButtons = ({
           <Button
             size={"md"}
             h={100}
-            color={colorScheme}
+            color={colorSelector(textElement)}
             variant={copied ? "light" : "outline"}
-            onClick={copy}
+            onClick={() => {
+              copy()
+              if (!copyHistory || copyHistory[0]["value"] !== value) {
+                setCopyHistory((history) => [
+                  ...history,
+                  {
+                    id: history.length,
+                    type: textElement,
+                    value: value,
+                  },
+                ])
+              }
+            }}
           >
             {copied ? `Copied ${label}` : label}
           </Button>

--- a/components/TextGeneration.tsx
+++ b/components/TextGeneration.tsx
@@ -72,6 +72,7 @@ export default function CopyGroupCard({ defaultOptions }: Props) {
             defaultValue={theme}
             onChange={(value) => setTheme(value as string)}
             pb={16}
+            withinPortal
           />
         </Grid.Col>
       </Grid>

--- a/extensionReqs/manifest.json
+++ b/extensionReqs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AliasIpsum",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "action": {
     "default_popup": "/extension.html",
     "default_title": "AliasIpsum",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quick-lorem",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quick-lorem",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "GPL",
       "dependencies": {
         "@emotion/react": "^11.10.6",
@@ -22,10 +22,14 @@
         "analytics": "github:vercel/analytics",
         "eslint": "8.39.0",
         "eslint-config-next": "13.3.1",
+        "jotai": "^2.2.2",
         "next": "13.3.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "typescript": "5.0.4"
+      },
+      "devDependencies": {
+        "@swc-jotai/react-refresh": "^0.0.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -826,6 +830,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
+    },
+    "node_modules/@swc-jotai/react-refresh": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@swc-jotai/react-refresh/-/react-refresh-0.0.8.tgz",
+      "integrity": "sha512-fHMenTg1jeETEShCh/wlDxRpR6DZAXIuDuFIB9fZ4yf+JfrWzQkPIvPN3E0efSpOham9ucRspS0uI82PxBbCjg==",
+      "dev": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.0",
@@ -3242,6 +3252,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jotai": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.2.2.tgz",
+      "integrity": "sha512-Cn8hnBg1sc5ppFwEgVGTfMR5WSM0hbAasd/bdAwIwTaum0j3OUPqBSC4tyk3jtB95vicML+RRWgKFOn6gtfN0A==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/js-sdsl": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.0.4"
+  },
+  "devDependencies": {
+    "@swc-jotai/react-refresh": "^0.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quick-lorem",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "Mikey Villavicencio",
     "email": "villavicem@gmail.com"
@@ -41,6 +41,7 @@
     "analytics": "github:vercel/analytics",
     "eslint": "8.39.0",
     "eslint-config-next": "13.3.1",
+    "jotai": "^2.2.2",
     "next": "13.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,7 +4,6 @@ import Head from "next/head"
 import {
   AppShell,
   Aside,
-  Badge,
   Button,
   ColorScheme,
   ColorSchemeProvider,
@@ -81,6 +80,25 @@ export default function App(props: AppProps) {
   )
 }
 
+const ClearHistoryButton = () => {
+  const setHistory = useSetAtom(localCopyHistoryAtom)
+  const handleDeleteHistory = () => {
+    setHistory(RESET)
+  }
+
+  return (
+    <ConfirmationPopup
+      description="Are you sure you want to clear your copy history?"
+      confirmLabel="Delete"
+      cancelLabel="Cancel"
+      onConfirm={() => handleDeleteHistory()}
+      confirmColor="red"
+      cancelColor="gray"
+      position="center"
+    />
+  )
+}
+
 function ExtentionLayout({
   colorScheme,
   children,
@@ -91,8 +109,22 @@ function ExtentionLayout({
   children: React.ReactNode
   [x: string]: any
 }) {
+  const extensionWidth = "380px"
+  const extensionHeight = "400px"
   return (
-    <AppShell w={"380px"} {...rest}>
+    <AppShell
+      w={extensionWidth}
+      h={extensionHeight}
+      {...rest}
+      footer={
+        <Footer w={extensionWidth} height={"100px"}>
+          <ScrollArea h={76} type="always">
+            <CopyHistory type="email" spacing={1} />
+          </ScrollArea>
+          <ClearHistoryButton />
+        </Footer>
+      }
+    >
       {children}
     </AppShell>
   )
@@ -107,11 +139,6 @@ function DefaultLayout({
   children: React.ReactNode
   [x: string]: any
 }) {
-  const setHistory = useSetAtom(localCopyHistoryAtom)
-  const handleDeleteHistory = () => {
-    setHistory(RESET)
-  }
-
   return (
     <AppShell
       padding="md"
@@ -148,17 +175,7 @@ function DefaultLayout({
         <MediaQuery smallerThan="sm" styles={{ display: "none" }}>
           <Aside p="sm" hiddenBreakpoint="sm" width={{ sm: 200, lg: 300 }}>
             <Aside.Section pb={16}>
-              <ConfirmationPopup
-                description="Are you sure you want to clear your copy history?"
-                confirmLabel="Delete"
-                cancelLabel="Cancel"
-                onConfirm={() => handleDeleteHistory()}
-                confirmColor="red"
-                cancelColor="gray"
-                position="center"
-              >
-                <Badge w={"100%"}>Clear History</Badge>
-              </ConfirmationPopup>
+              <ClearHistoryButton />
             </Aside.Section>
             <Aside.Section grow component={ScrollArea}>
               <CopyHistory />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,7 +22,7 @@ import Link from "next/link"
 import { IconBrandGithub } from "@tabler/icons-react"
 import HomepageHero from "../components/HomepageHero"
 import { useRouter } from "next/router"
-import { Provider as JotaiProvider, useSetAtom } from "jotai"
+import { Provider as JotaiProvider, useAtom } from "jotai"
 import CopyHistory from "@/components/CopyHistory"
 import ConfirmationPopup from "@/components/ConfirmationPopup"
 import { localCopyHistoryAtom } from "@/components/AliasedEmails"
@@ -81,11 +81,12 @@ export default function App(props: AppProps) {
 }
 
 const ClearHistoryButton = () => {
-  const setHistory = useSetAtom(localCopyHistoryAtom)
+  const [history, setHistory] = useAtom(localCopyHistoryAtom)
   const handleDeleteHistory = () => {
     setHistory(RESET)
   }
 
+  if (history.length === 0) return null
   return (
     <ConfirmationPopup
       description="Are you sure you want to clear your copy history?"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import Head from "next/head"
 import {
   AppShell,
   Aside,
+  Badge,
   Button,
   ColorScheme,
   ColorSchemeProvider,
@@ -12,6 +13,7 @@ import {
   Header,
   MantineProvider,
   MediaQuery,
+  ScrollArea,
   Title,
 } from "@mantine/core"
 import { useHotkeys, useLocalStorage } from "@mantine/hooks"
@@ -21,10 +23,11 @@ import Link from "next/link"
 import { IconBrandGithub } from "@tabler/icons-react"
 import HomepageHero from "../components/HomepageHero"
 import { useRouter } from "next/router"
-import { Loader } from "@mantine/core"
-import { useEffect, useState } from "react"
-import { Provider as JotaiProvider } from "jotai"
+import { Provider as JotaiProvider, useSetAtom } from "jotai"
 import CopyHistory from "@/components/CopyHistory"
+import ConfirmationPopup from "@/components/ConfirmationPopup"
+import { localCopyHistoryAtom } from "@/components/AliasedEmails"
+import { RESET } from "jotai/utils"
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props
@@ -104,6 +107,11 @@ function DefaultLayout({
   children: React.ReactNode
   [x: string]: any
 }) {
+  const setHistory = useSetAtom(localCopyHistoryAtom)
+  const handleDeleteHistory = () => {
+    setHistory(RESET)
+  }
+
   return (
     <AppShell
       padding="md"
@@ -138,8 +146,23 @@ function DefaultLayout({
       }
       aside={
         <MediaQuery smallerThan="sm" styles={{ display: "none" }}>
-          <Aside p="md" hiddenBreakpoint="sm" width={{ sm: 200, lg: 300 }}>
-            <CopyHistory />
+          <Aside p="sm" hiddenBreakpoint="sm" width={{ sm: 200, lg: 300 }}>
+            <Aside.Section pb={16}>
+              <ConfirmationPopup
+                description="Are you sure you want to clear your copy history?"
+                confirmLabel="Delete"
+                cancelLabel="Cancel"
+                onConfirm={() => handleDeleteHistory()}
+                confirmColor="red"
+                cancelColor="gray"
+                position="center"
+              >
+                <Badge w={"100%"}>Clear History</Badge>
+              </ConfirmationPopup>
+            </Aside.Section>
+            <Aside.Section grow component={ScrollArea}>
+              <CopyHistory />
+            </Aside.Section>
           </Aside>
         </MediaQuery>
       }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,6 +22,7 @@ import HomepageHero from "../components/HomepageHero"
 import { useRouter } from "next/router"
 import { Loader } from "@mantine/core"
 import { useEffect, useState } from "react"
+import { Provider as JotaiProvider } from "jotai"
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props
@@ -63,10 +64,12 @@ export default function App(props: AppProps) {
             loader: "bars",
           }}
         >
-          <Layout colorScheme={colorScheme}>
-            <Component {...pageProps} />
-            <Analytics />
-          </Layout>
+          <JotaiProvider>
+            <Layout colorScheme={colorScheme}>
+              <Component {...pageProps} />
+              <Analytics />
+            </Layout>
+          </JotaiProvider>
         </MantineProvider>
       </ColorSchemeProvider>
     </>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,14 +3,15 @@ import { Analytics } from "@vercel/analytics/react"
 import Head from "next/head"
 import {
   AppShell,
+  Aside,
   Button,
-  Center,
   ColorScheme,
   ColorSchemeProvider,
   Footer,
   Group,
   Header,
   MantineProvider,
+  MediaQuery,
   Title,
 } from "@mantine/core"
 import { useHotkeys, useLocalStorage } from "@mantine/hooks"
@@ -23,6 +24,7 @@ import { useRouter } from "next/router"
 import { Loader } from "@mantine/core"
 import { useEffect, useState } from "react"
 import { Provider as JotaiProvider } from "jotai"
+import CopyHistory from "@/components/CopyHistory"
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props
@@ -133,6 +135,13 @@ function DefaultLayout({
             <ColorSwitcher />
           </Group>
         </Header>
+      }
+      aside={
+        <MediaQuery smallerThan="sm" styles={{ display: "none" }}>
+          <Aside p="md" hiddenBreakpoint="sm" width={{ sm: 200, lg: 300 }}>
+            <CopyHistory />
+          </Aside>
+        </MediaQuery>
       }
       footer={
         <Footer height={100} fixed={false}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -25,8 +25,7 @@ import { useRouter } from "next/router"
 import { Provider as JotaiProvider, useAtom } from "jotai"
 import CopyHistory from "@/components/CopyHistory"
 import ConfirmationPopup from "@/components/ConfirmationPopup"
-import { localCopyHistoryAtom } from "@/components/AliasedEmails"
-import { RESET } from "jotai/utils"
+import { RESET, atomWithStorage } from "jotai/utils"
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props
@@ -79,6 +78,17 @@ export default function App(props: AppProps) {
     </>
   )
 }
+
+export type CopyHistory = {
+  id: number
+  type: string
+  value: string
+}
+
+export const localCopyHistoryAtom = atomWithStorage(
+  "copyHistory",
+  [] as CopyHistory[]
+)
 
 const ClearHistoryButton = () => {
   const [history, setHistory] = useAtom(localCopyHistoryAtom)

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -112,15 +112,21 @@ function ExtentionLayout({
 }) {
   const extensionWidth = "380px"
   const extensionHeight = "400px"
+
   return (
     <AppShell
       w={extensionWidth}
       h={extensionHeight}
       {...rest}
       footer={
-        <Footer w={extensionWidth} height={"100px"}>
+        <Footer
+          w={extensionWidth}
+          height={"100px"}
+          px={"xs"}
+          withBorder={false}
+        >
           <ScrollArea h={76} type="always">
-            <CopyHistory type="email" spacing={1} />
+            <CopyHistory type="email" spacing={1} tooltip={false} />
           </ScrollArea>
           <ClearHistoryButton />
         </Footer>
@@ -179,7 +185,7 @@ function DefaultLayout({
               <ClearHistoryButton />
             </Aside.Section>
             <Aside.Section grow component={ScrollArea}>
-              <CopyHistory />
+              <CopyHistory threshold={29} />
             </Aside.Section>
           </Aside>
         </MediaQuery>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -125,8 +125,13 @@ function ExtentionLayout({
           px={"xs"}
           withBorder={false}
         >
-          <ScrollArea h={76} type="always">
-            <CopyHistory type="email" spacing={1} tooltip={false} />
+          <ScrollArea h={76} type="auto" offsetScrollbars>
+            <CopyHistory
+              type="email"
+              spacing={1}
+              tooltip={false}
+              scrollThreshold={38}
+            />
           </ScrollArea>
           <ClearHistoryButton />
         </Footer>
@@ -185,7 +190,7 @@ function DefaultLayout({
               <ClearHistoryButton />
             </Aside.Section>
             <Aside.Section grow component={ScrollArea}>
-              <CopyHistory threshold={29} />
+              <CopyHistory scrollThreshold={29} />
             </Aside.Section>
           </Aside>
         </MediaQuery>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,8 +14,8 @@ export default function Home() {
       </Head>
       <Container>
         <SimpleGrid>
-          <TextGeneration defaultOptions={options} />
           <AliasedEmails />
+          <TextGeneration defaultOptions={options} />
         </SimpleGrid>
       </Container>
     </>

--- a/utils/colorSelector.ts
+++ b/utils/colorSelector.ts
@@ -1,0 +1,20 @@
+export const colorSelector = (textElement: string) => {
+  switch (textElement) {
+    case "sentences":
+      return "teal"
+    case "paragraphs":
+      return "indigo"
+    case "words":
+      return "red"
+    case "json":
+      return "orange"
+    case "array":
+      return "yellow"
+    case "email":
+      return "blue"
+    case "list":
+      return "lime"
+    default:
+      return "black"
+  }
+}


### PR DESCRIPTION
Adds copy history to the website and to the extension. In case you need to remember what that email was that you copied the other day
Copy history can be any data type, as long as it isn't the last thing copied. 
Clear history to start a clean slate over again.
Color of the history matches the color of the original copy button